### PR TITLE
Fix for stale voyage missions.

### DIFF
--- a/DistantSeas/Fishing/DebugStateTracker.cs
+++ b/DistantSeas/Fishing/DebugStateTracker.cs
@@ -38,4 +38,12 @@ public class DebugStateTracker : IStateTracker {
     }
 
     public void Dispose() { }
+
+    public void ResetMissions() {
+        MissionState = new() {
+            new MissionState(0),
+            new MissionState(0),
+            new MissionState(0)
+        };
+    }
 }

--- a/DistantSeas/Fishing/IStateTracker.cs
+++ b/DistantSeas/Fishing/IStateTracker.cs
@@ -21,4 +21,5 @@ public interface IStateTracker : IDisposable {
     public bool IsActionReady(uint id);
     public uint GetStatusStacks(uint id);
     public int GetItemCount(uint id);
+    public void ResetMissions();
 }

--- a/DistantSeas/Fishing/NormalStateTracker.cs
+++ b/DistantSeas/Fishing/NormalStateTracker.cs
@@ -153,4 +153,8 @@ public unsafe class NormalStateTracker : IStateTracker {
             }
         }
     }
+
+    public void ResetMissions() {
+        MissionState.Clear();
+    }
 }

--- a/DistantSeas/Tracking/Journal.cs
+++ b/DistantSeas/Tracking/Journal.cs
@@ -158,6 +158,8 @@ public unsafe class Journal : IDisposable {
         this.missionTwo = 0;
         this.missionThree = 0;
         this.pollingForDataPopulation = false;
+
+        Plugin.StateTracker.ResetMissions();
     }
 
     // public for debugging purposes


### PR DESCRIPTION
Tested this on two consecutive boats without logging out which is what triggered the glitch #1  in my testing.

Added the additional function in the IStateTracker interface so that the DebugStateTracker could also reset its voyage missions if you use the Exit Boat button.

I could see an argument to be made to instead reset missions when you enter a boat rather than exiting, but either way works.
